### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,6 @@
 name: Lighthouse CI
+permissions:
+  contents: read
 on: push
 jobs:
   lighthouse:


### PR DESCRIPTION
Potential fix for [https://github.com/failxontour/failxontour.de/security/code-scanning/4](https://github.com/failxontour/failxontour.de/security/code-scanning/4)

**General approach:**  
To enforce least privilege for the GitHub Actions token, explicitly define the `permissions` for the workflow. This can be added either at the root of the workflow file—applying to all jobs by default—or under a specific job. The minimal, safest starting point is `permissions: contents: read`. If the job does not need to write to the repo or interact with issues, pull requests, etc., this is sufficient.

**Specific fix:**  
Add a `permissions:` block at the top-level of the file (line 2, after `name:` and before `on:`) or inside the `lighthouse` job (on line 5, before `runs-on`). Since there's only one job here, putting it at the top level makes it clear and applies the restriction globally.

**File/region to change:**  
.github/workflows/main.yml – Insert the `permissions:` block after the `name:` field and before `on:`.

**Requirements:**  
No imports or extra methods are needed. Just define the YAML structure appropriately.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
